### PR TITLE
(bug) issue where slug wasn't getting passed to downgraded

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/squirrel v1.5.3
 	github.com/alecthomas/chroma v0.10.0
 	github.com/alecthomas/kingpin/v2 v2.3.1
-	github.com/drone/go-convert v0.0.0-20230331142646-79558c51575c
+	github.com/drone/go-convert v0.0.0-20230404110536-e064bd8b55b9
 	github.com/drone/go-scm v1.28.1
 	github.com/go-git/go-git/v5 v5.5.2
 	github.com/google/go-cmp v0.5.9
@@ -38,6 +38,7 @@ require (
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.4.0 // indirect
 	github.com/go-sql-driver/mysql v1.7.0 // indirect
+	github.com/google/subcommands v1.2.0 // indirect
 	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/drone/go-convert v0.0.0-20230331142646-79558c51575c h1:/14sTkYRr2asHzD/O8I+HSXgYe7DrpRWCHhItiLbg8Q=
 github.com/drone/go-convert v0.0.0-20230331142646-79558c51575c/go.mod h1:aGyq3jDZrHPuHY26DDXNgIMtY70N4XVSBig7wwQE9ZE=
+github.com/drone/go-convert v0.0.0-20230404110536-e064bd8b55b9 h1:2pRrRR9i8M7BjDjkZ2s7dqJ0t756y5OuCYmTmUML2eA=
+github.com/drone/go-convert v0.0.0-20230404110536-e064bd8b55b9/go.mod h1:aGyq3jDZrHPuHY26DDXNgIMtY70N4XVSBig7wwQE9ZE=
 github.com/drone/go-scm v1.28.1 h1:3WukxtsFFU5omHfp8dU3EXjEQCmtqAZkCj9pHHs+Xus=
 github.com/drone/go-scm v1.28.1/go.mod h1:DFIJJjhMj0TSXPz+0ni4nyZ9gtTtC40Vh/TGRugtyWw=
 github.com/drone/spec v0.0.0-20230330193014-737aceb47e26 h1:X7tVVHfcmYfvy+oirywynFQvvA6kFTQUsvV9erIwHt8=
@@ -58,6 +60,8 @@ github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN9oE=
+github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/gotidy/ptr v1.4.0 h1:7++suUs+HNHMnyz6/AW3SE+4EnBhupPSQTSI7QNijVc=
 github.com/gotidy/ptr v1.4.0/go.mod h1:MjRBG6/IETiiZGWI8LrRtISXEji+8b/jigmj2q0mEyM=
 github.com/h2non/gock v1.0.9/go.mod h1:CZMcB0Lg5IWnr9bF79pPMg9WeV6WumxQiUJ1UvdO1iE=


### PR DESCRIPTION
We now pass the slug, so the pipeline yaml has the stripped of '-' version.
Also pulls latest go-convert which contains fixes for 'when' conditions @ step level

Issue fixed: https://github.com/harness/harness-migrate/issues/8