### PR TITLE
feat: export should not convert yaml

### DIFF
--- a/cmd/drone/export.go
+++ b/cmd/drone/export.go
@@ -32,10 +32,9 @@ import (
 )
 
 type exportCommand struct {
-	debug     bool
-	downgrade bool
-	trace     bool
-	file      string
+	debug bool
+	trace bool
+	file  string
 
 	Driver         string
 	Datasource     string
@@ -45,13 +44,6 @@ type exportCommand struct {
 	githubToken    string
 	gitlabToken    string
 	bitbucketToken string
-
-	proj       string
-	org        string
-	repoConn   string
-	kubeName   string
-	kubeConn   string
-	dockerConn string
 }
 
 func (c *exportCommand) run(*kingpin.ParseContext) error {
@@ -94,18 +86,12 @@ func (c *exportCommand) run(*kingpin.ParseContext) error {
 
 	// extract the data
 	exporter := &drone.Exporter{
-		Downgrade:      c.downgrade,
 		Repository:     droneRepo,
 		Namespace:      c.namespace,
 		Tracer:         tracer_,
 		ScmClient:      client,
 		ScmLogin:       user.Login,
 		RepositoryList: repository,
-		DockerConn:     c.dockerConn,
-		KubeName:       c.kubeName,
-		KubeConn:       c.kubeConn,
-		Org:            c.org,
-		RepoConn:       c.repoConn,
 	}
 	data, err := exporter.Export(ctx)
 	if err != nil {
@@ -138,10 +124,6 @@ func registerExport(app *kingpin.CmdClause) {
 
 	cmd.Arg("save", "save the output to a file").
 		StringVar(&c.file)
-
-	cmd.Flag("downgrade", "downgrade to the legacy yaml format").
-		Default("true").
-		BoolVar(&c.downgrade)
 
 	cmd.Flag("namespace", "drone namespace").
 		Required().
@@ -178,28 +160,4 @@ func registerExport(app *kingpin.CmdClause) {
 
 	cmd.Flag("trace", "enable trace logging").
 		BoolVar(&c.trace)
-
-	cmd.Flag("org", "harness organization").
-		Default("default").
-		StringVar(&c.org)
-
-	cmd.Flag("project", "harness project").
-		Default("default").
-		StringVar(&c.proj)
-
-	cmd.Flag("repo-connector", "repository connector").
-		Default("").
-		StringVar(&c.repoConn)
-
-	cmd.Flag("kube-connector", "kubernetes connector").
-		Default("").
-		StringVar(&c.kubeConn)
-
-	cmd.Flag("kube-namespace", "kubernetes namespace").
-		Default("").
-		StringVar(&c.kubeName)
-
-	cmd.Flag("docker-connector", "dockerhub connector").
-		Default("").
-		StringVar(&c.kubeName)
 }

--- a/cmd/drone/import.go
+++ b/cmd/drone/import.go
@@ -91,8 +91,6 @@ func (c *importCommand) run(*kingpin.ParseContext) error {
 		if c.downgrade {
 			d := downgrader.New(
 				downgrader.WithCodebase(project.Name, c.repoConn),
-				downgrader.WithDockerhub(c.dockerConn),
-				downgrader.WithKubernetes(c.kubeName, c.kubeConn),
 				downgrader.WithName(project.Name),
 				downgrader.WithOrganization(c.harnessOrg),
 				downgrader.WithProject(project.Name),

--- a/cmd/drone/import.go
+++ b/cmd/drone/import.go
@@ -91,6 +91,8 @@ func (c *importCommand) run(*kingpin.ParseContext) error {
 		if c.downgrade {
 			d := downgrader.New(
 				downgrader.WithCodebase(project.Name, c.repoConn),
+				downgrader.WithDockerhub(c.dockerConn),
+				downgrader.WithKubernetes(c.kubeName, c.kubeConn),
 				downgrader.WithName(project.Name),
 				downgrader.WithOrganization(c.harnessOrg),
 				downgrader.WithProject(project.Name),
@@ -177,14 +179,6 @@ func registerImport(app *kingpin.CmdClause) {
 		Required().
 		Envar("HARNESS_TOKEN").
 		StringVar(&c.harnessToken)
-
-	cmd.Flag("kube-namespace", "kubernetes namespace").
-		Envar("KUBE_NAMESPACE").
-		StringVar(&c.KubeName)
-
-	cmd.Flag("kube-connector", "kubernetes connector").
-		Envar("KUBE_CONN").
-		StringVar(&c.KubeConn)
 
 	cmd.Flag("harness-address", "harness address").
 		Envar("HARNESS_ADDRESS").

--- a/cmd/drone/import.go
+++ b/cmd/drone/import.go
@@ -206,11 +206,11 @@ func registerImport(app *kingpin.CmdClause) {
 		BoolVar(&c.downgrade)
 
 	cmd.Flag("kube-connector", "kubernetes connector").
-		Default("").
+		Envar("KUBE_CONN").
 		StringVar(&c.kubeConn)
 
 	cmd.Flag("kube-namespace", "kubernetes namespace").
-		Default("").
+		Envar("KUBE_NAMESPACE").
 		StringVar(&c.kubeName)
 
 	cmd.Flag("docker-connector", "dockerhub connector").

--- a/cmd/drone/import.go
+++ b/cmd/drone/import.go
@@ -22,6 +22,7 @@ import (
 	"github.com/drone/go-convert/convert/drone"
 	"github.com/drone/go-convert/convert/harness/downgrader"
 	"github.com/harness/harness-migrate/cmd/util"
+	"github.com/harness/harness-migrate/internal/slug"
 	"github.com/harness/harness-migrate/internal/tracer"
 	"github.com/harness/harness-migrate/internal/types"
 
@@ -95,7 +96,7 @@ func (c *importCommand) run(*kingpin.ParseContext) error {
 				downgrader.WithKubernetes(c.kubeName, c.kubeConn),
 				downgrader.WithName(project.Name),
 				downgrader.WithOrganization(c.harnessOrg),
-				downgrader.WithProject(project.Name),
+				downgrader.WithProject(slug.Create(project.Name)),
 			)
 			convertedYaml, err = d.Downgrade(convertedYaml)
 			if err != nil {

--- a/cmd/drone/migrate.go
+++ b/cmd/drone/migrate.go
@@ -20,6 +20,7 @@ import (
 
 	convert "github.com/drone/go-convert/convert/drone"
 	migrate "github.com/harness/harness-migrate/internal/migrate/drone"
+	"github.com/harness/harness-migrate/internal/slug"
 
 	"github.com/drone/go-convert/convert/harness/downgrader"
 	"github.com/harness/harness-migrate/cmd/util"
@@ -128,7 +129,7 @@ func (c *migrateCommand) run(*kingpin.ParseContext) error {
 				downgrader.WithKubernetes(c.kubeName, c.kubeConn),
 				downgrader.WithName(project.Name),
 				downgrader.WithOrganization(c.harnessOrg),
-				downgrader.WithProject(project.Name),
+				downgrader.WithProject(slug.Create(project.Name)),
 			)
 			convertedYaml, err = d.Downgrade(convertedYaml)
 			if err != nil {

--- a/cmd/drone/migrate.go
+++ b/cmd/drone/migrate.go
@@ -124,6 +124,8 @@ func (c *migrateCommand) run(*kingpin.ParseContext) error {
 		if c.downgrade {
 			d := downgrader.New(
 				downgrader.WithCodebase(project.Name, c.repoConn),
+				downgrader.WithDockerhub(c.dockerConn),
+				downgrader.WithKubernetes(c.kubeName, c.kubeConn),
 				downgrader.WithName(project.Name),
 				downgrader.WithOrganization(c.harnessOrg),
 				downgrader.WithProject(project.Name),
@@ -214,14 +216,6 @@ func registerMigrate(app *kingpin.CmdClause) {
 	cmd.Flag("downgrade", "downgrade to the legacy yaml format").
 		Default("true").
 		BoolVar(&c.downgrade)
-
-	cmd.Flag("kube-namespace", "kubernetes namespace").
-		Envar("KUBE_NAMESPACE").
-		StringVar(&c.KubeName)
-
-	cmd.Flag("kube-connector", "kubernetes connector").
-		Envar("KUBE_CONN").
-		StringVar(&c.KubeConn)
 
 	cmd.Flag("namespace", "drone namespace").
 		Required().

--- a/cmd/drone/migrate.go
+++ b/cmd/drone/migrate.go
@@ -18,10 +18,11 @@ import (
 	"context"
 	"strings"
 
-	gcDrone "github.com/drone/go-convert/convert/drone"
+	convert "github.com/drone/go-convert/convert/drone"
+	migrate "github.com/harness/harness-migrate/internal/migrate/drone"
+
 	"github.com/drone/go-convert/convert/harness/downgrader"
 	"github.com/harness/harness-migrate/cmd/util"
-	"github.com/harness/harness-migrate/internal/migrate/drone"
 	"github.com/harness/harness-migrate/internal/migrate/drone/repo"
 	"github.com/harness/harness-migrate/internal/tracer"
 
@@ -96,7 +97,7 @@ func (c *migrateCommand) run(*kingpin.ParseContext) error {
 	defer tracer_.Close()
 
 	// extract the data
-	exporter := &drone.Exporter{
+	exporter := &migrate.Exporter{
 		Repository:     droneRepo,
 		Namespace:      c.namespace,
 		Tracer:         tracer_,
@@ -109,9 +110,9 @@ func (c *migrateCommand) run(*kingpin.ParseContext) error {
 	}
 
 	// convert all yaml into v1 or v0 format
-	converter := gcDrone.New(
-		gcDrone.WithDockerhub(c.dockerConn),
-		gcDrone.WithKubernetes(c.kubeName, c.kubeConn),
+	converter := convert.New(
+		convert.WithDockerhub(c.dockerConn),
+		convert.WithKubernetes(c.kubeName, c.kubeConn),
 	)
 	for _, project := range data.Projects {
 		// convert to v1
@@ -123,8 +124,6 @@ func (c *migrateCommand) run(*kingpin.ParseContext) error {
 		if c.downgrade {
 			d := downgrader.New(
 				downgrader.WithCodebase(project.Name, c.repoConn),
-				downgrader.WithDockerhub(c.dockerConn),
-				downgrader.WithKubernetes(c.kubeName, c.kubeConn),
 				downgrader.WithName(project.Name),
 				downgrader.WithOrganization(c.harnessOrg),
 				downgrader.WithProject(project.Name),

--- a/cmd/drone/migrate.go
+++ b/cmd/drone/migrate.go
@@ -239,11 +239,11 @@ func registerMigrate(app *kingpin.CmdClause) {
 		BoolVar(&c.trace)
 
 	cmd.Flag("kube-connector", "kubernetes connector").
-		Default("").
+		Envar("KUBE_CONN").
 		StringVar(&c.kubeConn)
 
 	cmd.Flag("kube-namespace", "kubernetes namespace").
-		Default("").
+		Envar("KUBE_NAMESPACE").
 		StringVar(&c.kubeName)
 
 	cmd.Flag("docker-connector", "dockerhub connector").

--- a/cmd/terraform/terraform.go
+++ b/cmd/terraform/terraform.go
@@ -115,8 +115,6 @@ func (c *terraformCommand) run(ctx *kingpin.ParseContext) error {
 		if c.downgrade {
 			d := downgrader.New(
 				downgrader.WithCodebase(project.Name, c.repoConn),
-				downgrader.WithDockerhub(c.dockerConn),
-				downgrader.WithKubernetes(c.kubeName, c.kubeConn),
 				downgrader.WithName(project.Name),
 				downgrader.WithOrganization(c.organization),
 				downgrader.WithProject(project.Name),

--- a/cmd/terraform/terraform.go
+++ b/cmd/terraform/terraform.go
@@ -115,6 +115,8 @@ func (c *terraformCommand) run(ctx *kingpin.ParseContext) error {
 		if c.downgrade {
 			d := downgrader.New(
 				downgrader.WithCodebase(project.Name, c.repoConn),
+				downgrader.WithDockerhub(c.dockerConn),
+				downgrader.WithKubernetes(c.kubeName, c.kubeConn),
 				downgrader.WithName(project.Name),
 				downgrader.WithOrganization(c.organization),
 				downgrader.WithProject(project.Name),

--- a/cmd/terraform/terraform.go
+++ b/cmd/terraform/terraform.go
@@ -227,11 +227,11 @@ func Register(app *kingpin.Application) {
 		StringVar(&c.providerVersion)
 
 	cmd.Flag("kube-connector", "kubernetes connector").
-		Default("").
+		Envar("KUBE_CONN").
 		StringVar(&c.kubeConn)
 
 	cmd.Flag("kube-namespace", "kubernetes namespace").
-		Default("").
+		Envar("KUBE_NAMESPACE").
 		StringVar(&c.kubeName)
 
 	cmd.Flag("docker-connector", "dockerhub connector").

--- a/cmd/terraform/terraform.go
+++ b/cmd/terraform/terraform.go
@@ -119,7 +119,7 @@ func (c *terraformCommand) run(ctx *kingpin.ParseContext) error {
 				downgrader.WithKubernetes(c.kubeName, c.kubeConn),
 				downgrader.WithName(project.Name),
 				downgrader.WithOrganization(c.organization),
-				downgrader.WithProject(project.Name),
+				downgrader.WithProject(slug.Create(project.Name)),
 			)
 			convertedYaml, err = d.Downgrade(convertedYaml)
 			if err != nil {

--- a/cmd/terraform/terraform.go
+++ b/cmd/terraform/terraform.go
@@ -22,8 +22,11 @@ import (
 	"os"
 	"text/template"
 
+	"github.com/drone/go-convert/convert/drone"
+	"github.com/drone/go-convert/convert/harness/downgrader"
 	"github.com/harness/harness-migrate/internal/slug"
 	"github.com/harness/harness-migrate/internal/types"
+
 	"gopkg.in/yaml.v2"
 
 	"github.com/alecthomas/chroma/quick"
@@ -47,6 +50,12 @@ type terraformCommand struct {
 	organization    string
 	providerSource  string
 	providerVersion string
+	repoConn        string
+	kubeName        string
+	kubeConn        string
+	dockerConn      string
+
+	downgrade bool
 
 	color bool
 	theme string
@@ -89,6 +98,35 @@ func (c *terraformCommand) run(ctx *kingpin.ParseContext) error {
 			return err
 		}
 		tmpl = string(t)
+	}
+
+	// convert all yaml into v1 or v0 format
+	converter := drone.New(
+		drone.WithDockerhub(c.dockerConn),
+		drone.WithKubernetes(c.kubeName, c.kubeConn),
+	)
+	for _, project := range org.Projects {
+		// convert to v1
+		convertedYaml, err := converter.ConvertBytes(project.Yaml)
+		if err != nil {
+			return err
+		}
+		// downgrade to v0 if needed
+		if c.downgrade {
+			d := downgrader.New(
+				downgrader.WithCodebase(project.Name, c.repoConn),
+				downgrader.WithDockerhub(c.dockerConn),
+				downgrader.WithKubernetes(c.kubeName, c.kubeConn),
+				downgrader.WithName(project.Name),
+				downgrader.WithOrganization(c.organization),
+				downgrader.WithProject(project.Name),
+			)
+			convertedYaml, err = d.Downgrade(convertedYaml)
+			if err != nil {
+				return nil
+			}
+		}
+		project.Yaml = convertedYaml
 	}
 
 	// parse the terraform template
@@ -149,6 +187,13 @@ func Register(app *kingpin.Application) {
 	cmd.Arg("output", "path to save the terraform file").
 		StringVar(&c.output)
 
+	cmd.Flag("downgrade", "downgrade to the legacy yaml format").
+		// TODO: unhide when the pipeline tf resource supports v1 yaml,
+		//       until then, all pipelines must be downgraded to v0
+		Hidden().
+		Default("true").
+		BoolVar(&c.downgrade)
+
 	cmd.Flag("template", "path to the terraform template").
 		StringVar(&c.tmpl)
 
@@ -180,6 +225,22 @@ func Register(app *kingpin.Application) {
 	cmd.Flag("provider-version", "harness terraform provider version").
 		Default("0.17.5").
 		StringVar(&c.providerVersion)
+
+	cmd.Flag("kube-connector", "kubernetes connector").
+		Default("").
+		StringVar(&c.kubeConn)
+
+	cmd.Flag("kube-namespace", "kubernetes namespace").
+		Default("").
+		StringVar(&c.kubeName)
+
+	cmd.Flag("docker-connector", "dockerhub connector").
+		Default("").
+		StringVar(&c.dockerConn)
+
+	cmd.Flag("repo-connector", "repository connector").
+		Default("").
+		StringVar(&c.repoConn)
 }
 
 type (

--- a/internal/migrate/circle/export.go
+++ b/internal/migrate/circle/export.go
@@ -81,8 +81,8 @@ func (m *Exporter) Export(ctx context.Context) (*types.Org, error) {
 
 		// convert the circle project to a common format.
 		dstProject := &types.Project{
-			Name:         srcProject.Name,
-			OriginalYaml: []byte(config.Source),
+			Name: srcProject.Name,
+			Yaml: []byte(config.Source),
 		}
 
 		converter := circle.New()

--- a/internal/migrate/drone/export.go
+++ b/internal/migrate/drone/export.go
@@ -19,9 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/drone/go-convert/convert/drone"
-	"github.com/drone/go-convert/convert/harness/downgrader"
-
 	"github.com/drone/go-scm/scm"
 
 	"github.com/harness/harness-migrate/internal/migrate/drone/repo"
@@ -108,33 +105,7 @@ func (m *Exporter) Export(ctx context.Context) (*types.Org, error) {
 			return nil, err
 		}
 
-		dstProject.OriginalYaml = yamlFile.Data
-
-		converter := drone.New()
-		newYaml, err := converter.ConvertBytes(yamlFile.Data)
-		if err != nil {
-			return nil, err
-		}
-
-		// downgrade from the v1 harness yaml format
-		// to the v0 harness yaml format.
-		if m.Downgrade {
-			// downgrade to the v0 yaml
-			d := downgrader.New(
-				downgrader.WithCodebase(repo.Name, m.RepoConn),
-				downgrader.WithDockerhub(m.DockerConn),
-				downgrader.WithKubernetes(m.KubeName, m.KubeConn),
-				downgrader.WithName(repo.Name),
-				downgrader.WithOrganization(m.Org),
-				downgrader.WithProject(repo.Name),
-			)
-			newYaml, err = d.Downgrade(newYaml)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		dstProject.Yaml = newYaml
+		dstProject.Yaml = yamlFile.Data
 
 		// find Drone secrets
 		secrets, secretErr := m.Repository.GetSecrets(ctx, repo.ID)

--- a/internal/migrate/import.go
+++ b/internal/migrate/import.go
@@ -17,7 +17,6 @@ package migrate
 import (
 	"context"
 
-	"github.com/drone/go-convert/convert/harness/downgrader"
 	"github.com/drone/go-scm/scm"
 	"github.com/harness/harness-migrate/internal/harness"
 	"github.com/harness/harness-migrate/internal/slug"
@@ -172,23 +171,8 @@ func (m *Importer) Import(ctx context.Context, data *types.Org) error {
 			}
 		}
 
-		// downgrade to the v0 yaml
-		d := downgrader.New(
-			downgrader.WithCodebase(project.Name, connector.Identifier),
-			downgrader.WithDockerhub(dockerConnectorName),
-			downgrader.WithKubernetes(m.KubeName, m.KubeConn),
-			downgrader.WithName(project.Name),
-			downgrader.WithIdentifier(projectSlug),
-			downgrader.WithOrganization(project.Orgidentifier),
-			downgrader.WithProject(projectSlug),
-		)
-		after, err := d.Downgrade(srcProject.Yaml)
-		if err != nil {
-			return err
-		}
-
 		//create the harness pipeline with an inline yaml
-		err = m.Harness.CreatePipeline(org.ID, projectSlug, after)
+		err = m.Harness.CreatePipeline(org.ID, projectSlug, srcProject.Yaml)
 		if err != nil {
 			// if the error indicates the pipeline already
 			// exists we can continue with the import, else

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -25,13 +25,12 @@ type Org struct {
 
 // Project defines a project.
 type Project struct {
-	Name         string `json:"name"`
-	Desc         string `json:"desc,omitempty"`
-	Repo         string `json:"repo,omitempty"`
-	Branch       string `json:"branch,omitempty"`
-	Type         string `json:"type"` // github, gitlab, bitbucket
-	Yaml         []byte `json:"yaml"`
-	OriginalYaml []byte `json:"originalYaml,omitempty"`
+	Name   string `json:"name"`
+	Desc   string `json:"desc,omitempty"`
+	Repo   string `json:"repo,omitempty"`
+	Branch string `json:"branch,omitempty"`
+	Type   string `json:"type"` // github, gitlab, bitbucket
+	Yaml   []byte `json:"yaml"`
 
 	Secrets   []*Secret   `json:"secrets,omitempty"`
 	Pipelines []*Pipeline `json:"pipelines,omitempty"`


### PR DESCRIPTION
this change moves yaml conversion/downgrade out of `drone export` and into `drone import`, `drone migrate` and `terraform` subcommands

this keeps the original yaml "pristine" to reduce API calls to the service

the export should be run once, then `drone import`, `drone migrate` and `terraform` can run any number of times reading `export.json`